### PR TITLE
Custom seed files for immutable containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   - [Installation](#installation)
   - [Quickstart](#quickstart)
   - [Command-line arguments](#command-line-arguments)
+  - [Seed files](#seed-files)
   - [Persistence](#persistence)
 - [Maintenance](#maintenance)
   - [Upgrading](#upgrading)
@@ -87,6 +88,34 @@ docker run --name bind -it --rm \
   --volume /srv/docker/bind:/data \
   sameersbn/bind:9.9.5-20170626 -h
 ```
+
+## Seed files
+
+If you want to deploy as a proper immutable container across a docker swarm, you can
+put your seed configuration files in the /seed/etc and /seed/lib folders and they
+will be copied during container creation.
+
+This allows you to create a custom container with your own Dockerfile
+starting FROM this image, and just adding your own configuration files.
+
+Example Dockerfile:
+```Dockerfile
+FROM sameersbn/bind:9.9.5-20171215
+
+RUN mkdir -p /seed/etc && mkdir -p /seed/lib
+
+# This namde.conf.local file will point to the needed zone files
+COPY named.conf.local /seed/etc/
+# These are the actual zone files
+COPY mydomain.com.hosts /seed/lib/
+
+RUN chown bind:bind /seed/etc/named.conf.local \
+        && chown bind:bind /seed/lib/mydomain.com.hosts \
+        && chmod 644 /seed/lib/mydomain.com.hosts \
+        && chmod 775 /seed/etc/named.conf.local
+```
+
+You can build your own image and deploy on a swarm with docker stack deploy.
 
 ## Persistence
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,9 @@ create_bind_data_dir() {
   # populate default bind configuration if it does not exist
   if [ ! -d ${BIND_DATA_DIR}/etc ]; then
     mv /etc/bind ${BIND_DATA_DIR}/etc
+    if [ -d /seed/etc ]; then
+        mv /seed/etc/* ${BIND_DATA_DIR}/etc/
+    fi
   fi
   rm -rf /etc/bind
   ln -sf ${BIND_DATA_DIR}/etc /etc/bind
@@ -21,7 +24,10 @@ create_bind_data_dir() {
 
   if [ ! -d ${BIND_DATA_DIR}/lib ]; then
     mkdir -p ${BIND_DATA_DIR}/lib
-    chown ${BIND_USER}:${BIND_USER} ${BIND_DATA_DIR}/lib
+    if [ -d /seed/lib ]; then
+        mv -R /seed/lib/* ${BIND_DATA_DIR}/lib/
+    fi
+    chown -R ${BIND_USER}:${BIND_USER} ${BIND_DATA_DIR}/lib
   fi
   rm -rf /var/lib/bind
   ln -sf ${BIND_DATA_DIR}/lib /var/lib/bind


### PR DESCRIPTION
Modified entrypoint to allow for custom configuration files to be placed at /seed/etc and /seed/lib, so you can create derived images
with bundled dns configuration files.
That allows to create immutable containers that can be safely used
in a docker swarm (probably disabling webmin).